### PR TITLE
Swiper css

### DIFF
--- a/src/components/Carousel.astro
+++ b/src/components/Carousel.astro
@@ -5,62 +5,40 @@ import { getPastEventPhoto } from "../lib/microcms";
 const res = await getPastEventPhoto();
 ---
 <div class="swiper">
-  <div class="swiper-wrapper">
+  <div class="swiper-wrapper max-w-[1040px] pb-10">
   {res.images.map((image: any) => (
     <div class="swiper-slide">
       <Image src={image.url + "?w=350&h=350&fit=crop"} alt="past-event-photo" width={350} height={350} />
     </div>
-))}
-  <div class="swiper-pagination"></div>
+  ))}
   </div>
+  <!-- スクロールバーの横幅を狭くして、真ん中に配置している。!はimportantの意味。swiperが設定しているCSSを上書きしている -->
+  <div class="swiper-scrollbar max-w-[350px] !left-1/2 transform !-translate-x-1/2"></div>
 </div>
 
 <script>
   import Swiper from "swiper";
-  import { Pagination } from "swiper/modules";
+  import { Scrollbar } from "swiper/modules";
   import "swiper/css/bundle";
   import "swiper/css/pagination";
 
-  export const swiper = new Swiper(".swiper", {
+  new Swiper(".swiper", {
     slidesPerView: 3,
     spaceBetween: 10,
-    modules: [Pagination],
+    modules: [Scrollbar],
     loop: false,
-    speed: 1000,
-    pagination: {
-      el: ".swiper-pagination",
-      clickable: true,
-    },
+    speed: 400,
+    scrollbar: {
+      el: ".swiper-scrollbar",
+    }
   });
 </script>
 
 <style>
-  .swiper {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
 
-  .swiper-wrapper {
-    max-width: 1040px;
-  }
-  
-  .swiper-slide {
-    width: 350px;
-    height: 350px;
-  }
-
-  .swiper-pagination {
-    position: fixed;
-    bottom: 0;
-  }
-
-  .swiper-pagination-bullet {
-    width: 24px;
-    height: 24px;
-    background-color: red;
-  }
-
+/** スクロールカスタマイズ参考URL: https://swiperjs.com/swiper-api#scrollbar */
+.swiper-scrollbar {
+  --swiper-scrollbar-drag-bg-color: #E17A19 !important;
+  --swiper-scrollbar-bg-color: #FFF !important;
+}
 </style>

--- a/src/components/PastEvent.astro
+++ b/src/components/PastEvent.astro
@@ -37,7 +37,7 @@ const res = await getPastEvents();
         </div>
       ))}
     </article>
-    <article>
+    <article class="py-24">
       <Carousel />
     </article>
   </section>


### PR DESCRIPTION


### スクショ
オレンジの長さは登録画像が多ければ短くなっていきます（よくあるスクロールバーの動きと同じです）
<img width="1481" alt="Screenshot 2024-12-25 at 1 35 27" src="https://github.com/user-attachments/assets/2b923a24-13f3-4db1-a2c1-acc0d160ff42" />
